### PR TITLE
Map Explorer (kanto)

### DIFF
--- a/Website/MapExplorer/image-coords.html
+++ b/Website/MapExplorer/image-coords.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Image Coordinates</title>
+  <style>
+    .coords-box {
+      position: absolute;
+      background-color: rgba(255, 255, 255, 0.8);
+      border: 1px solid #000;
+      padding: 5px;
+      display: none;
+    }
+  </style>
+</head>
+<body>
+<img id="image" src="../Images/Locations/Regions/kanto.png" alt="Interactive Map">
+<div id="coords-box" class="coords-box"></div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const image = document.getElementById('image');
+    const coordsBox = document.getElementById('coords-box');
+
+    image.addEventListener('click', function(event) {
+      const rect = image.getBoundingClientRect();
+      const x = event.clientX - rect.left;
+      const y = event.clientY - rect.top;
+
+      coordsBox.style.left = `${event.pageX + 10}px`;
+      coordsBox.style.top = `${event.pageY + 10}px`;
+      coordsBox.textContent = `X: ${x}, Y: ${y}`;
+      coordsBox.style.display = 'block';
+    });
+
+    image.addEventListener('mouseout', function() {
+      coordsBox.style.display = 'none';
+    });
+  });
+</script>
+</body>
+</html>

--- a/Website/MapExplorer/location-info.html
+++ b/Website/MapExplorer/location-info.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Error</title>
+    <script src="location-info.js"></script>
+</head>
+<body>
+
+</body>
+</html>

--- a/Website/MapExplorer/location-info.html
+++ b/Website/MapExplorer/location-info.html
@@ -2,10 +2,14 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Error</title>
+    <title>Location Info</title>
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
     <script src="location-info.js"></script>
 </head>
-<body>
+<body class="container">
 
 </body>
 </html>

--- a/Website/MapExplorer/location-info.js
+++ b/Website/MapExplorer/location-info.js
@@ -1,0 +1,51 @@
+document.addEventListener("DOMContentLoaded", async function() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const locationType = urlParams.get('type'); // location-area, location or region
+    const location = urlParams.get('name');
+
+    document.title = location;
+
+    // Format location name to api name
+    const apiName = nameToApiName(location);
+
+    switch (locationType) {
+        case 'location-area':
+            await getLocationAreaData(apiName);
+            break;
+        case 'location':
+            await getLocationData(apiName);
+            break;
+        case 'region':
+            await getRegionData(apiName);
+            break;
+    }
+});
+
+async function getLocationAreaData(name) {
+    const response = await fetch(`https://pokeapi.co/api/v2/location-area/${name}`);
+    const data = await response.json();
+
+    const div = document.createElement('div');
+    div.innerText = JSON.stringify(data);
+    document.body.appendChild(div);
+}
+async function getLocationData(name) {
+    const response = await fetch(`https://pokeapi.co/api/v2/location/${name}`);
+    const data = await response.json();
+
+    const div = document.createElement('div');
+    div.innerText = JSON.stringify(data);
+    document.body.appendChild(div);
+}
+async function getRegionData(name) {
+    const response = await fetch(`https://pokeapi.co/api/v2/region/${name}`);
+    const data = await response.json();
+
+    const div = document.createElement('div');
+    div.innerText = JSON.stringify(data);
+    document.body.appendChild(div);
+}
+
+function nameToApiName(name) {
+    return name.toLowerCase().replace(/\s/g, '-');
+}

--- a/Website/MapExplorer/location-info.js
+++ b/Website/MapExplorer/location-info.js
@@ -169,5 +169,8 @@ async function fetchVersionEnglishName(name) {
 }
 
 function findEnglishName(data) {
+    if (data.names.length === 0) {
+        return data.name;
+    }
     return data.names.find(name => name.language.name === 'en').name;
 }

--- a/Website/MapExplorer/location-info.js
+++ b/Website/MapExplorer/location-info.js
@@ -2,50 +2,155 @@ document.addEventListener("DOMContentLoaded", async function() {
     const urlParams = new URLSearchParams(window.location.search);
     const locationType = urlParams.get('type'); // location-area, location or region
     const location = urlParams.get('name');
-
-    document.title = location;
-
-    // Format location name to api name
-    const apiName = nameToApiName(location);
+    const parent = urlParams.get('parent'); // Optional
 
     switch (locationType) {
         case 'location-area':
-            await getLocationAreaData(apiName);
+            await getLocationAreaData(location, parent);
             break;
         case 'location':
-            await getLocationData(apiName);
+            await getLocationData(location, parent);
             break;
         case 'region':
-            await getRegionData(apiName);
+            await getRegionData(location);
             break;
     }
 });
 
-async function getLocationAreaData(name) {
+async function getLocationAreaData(area, location) {
+    const response = await fetch(`https://pokeapi.co/api/v2/location-area/${area}`);
+    const data = await response.json();
+
+    const div = document.createElement('div');
+    div.classList.add('card', 'mt-4');
+
+    const name = findEnglishName(data);
+    const locationName = location ? location : data.location.name;
+    document.title = name;
+
+    const header = document.createElement('h1');
+    header.classList.add('card-header');
+    header.innerText = name + " (Area)";
+    div.appendChild(header);
+
+    const body = document.createElement('div');
+    body.classList.add('card-body');
+
+    const info = document.createElement('p');
+    info.classList.add('card-text');
+    info.innerText = "Location area in " + locationName;
+    body.appendChild(info);
+
+    const encounterHeader = document.createElement('h2');
+    encounterHeader.innerText = "Encounters";
+    body.appendChild(encounterHeader);
+
+    const encounters = document.createElement('ul');
+    encounters.classList.add('list-group', 'list-group-flush');
+    for (const encounter of data.pokemon_encounters) {
+        const li = document.createElement('li');
+        li.classList.add('list-group-item');
+
+        const text = document.createElement('a');
+        text.classList.add('btn', 'btn-primary');
+        text.setAttribute('data-toggle', 'collapse');
+        text.href = `#collapse-${encounter.pokemon.name}`;
+        text.innerText = encounter.pokemon.name;
+        li.appendChild(text);
+
+        const collapse = document.createElement('div');
+        collapse.classList.add('collapse', 'mt-3');
+        collapse.id = `collapse-${encounter.pokemon.name}`;
+        const card = document.createElement('div');
+        card.classList.add('card', 'card-body');
+
+        for (const version of encounter.version_details) {
+            const versionName = await fetchVersionEnglishName(version.version.name);
+            const versionHeader = document.createElement('h4');
+            versionHeader.innerText = versionName;
+            card.appendChild(versionHeader);
+
+            for (const encounterDetail of version.encounter_details) {
+                const encounterText = document.createElement('p');
+                encounterText.innerText = `Method: ${encounterDetail.method.name}, Chance: ${encounterDetail.chance}%`;
+                card.appendChild(encounterText);
+            }
+        }
+        collapse.appendChild(card);
+        li.appendChild(collapse);
+
+        encounters.appendChild(li);
+    }
+    body.appendChild(encounters);
+
+    div.appendChild(body);
+    document.body.appendChild(div);
+}
+
+async function getLocationData(location, region) {
+    const response = await fetch(`https://pokeapi.co/api/v2/location/${location}`);
+    const data = await response.json();
+
+    const div = document.createElement('div');
+    div.classList.add('card', 'mt-4');
+
+    const name = findEnglishName(data);
+    const regionName = region ? region : data.region.name;
+    document.title = name;
+
+    const header = document.createElement('h1');
+    header.classList.add('card-header');
+    header.innerText = name;
+    div.appendChild(header);
+
+    const body = document.createElement('div');
+    body.classList.add('card-body');
+
+    const info = document.createElement('p');
+    info.classList.add('card-text');
+    info.innerText = "Location in " + regionName;
+    body.appendChild(info);
+
+    const areaHeader = document.createElement('h2');
+    areaHeader.innerText = "Areas";
+    body.appendChild(areaHeader);
+
+    const areas = document.createElement('ul');
+    areas.classList.add('list-group', 'list-group-flush');
+    for (const area of data.areas) {
+        const li = document.createElement('li');
+        li.classList.add('list-group-item');
+        const areaName = await fetchAreaEnglishName(area.name);
+        li.innerHTML = `<a href="location-info.html?type=location-area&name=${area.name}&parent=${name}">${areaName}</a>`;
+        areas.appendChild(li);
+    }
+    body.appendChild(areas);
+
+    div.appendChild(body);
+    document.body.appendChild(div);
+}
+
+async function getRegionData(region) {
+    const response = await fetch(`https://pokeapi.co/api/v2/region/${region}`);
+    const data = await response.json();
+
+    const div = document.createElement('div');
+    div.classList.add('alert', 'alert-info');
+    div.innerText = JSON.stringify(data, null, 2);
+    document.body.appendChild(div);
+}
+
+async function fetchAreaEnglishName(name) {
     const response = await fetch(`https://pokeapi.co/api/v2/location-area/${name}`);
     const data = await response.json();
-
-    const div = document.createElement('div');
-    div.innerText = JSON.stringify(data);
-    document.body.appendChild(div);
+    return findEnglishName(data);
 }
-async function getLocationData(name) {
-    const response = await fetch(`https://pokeapi.co/api/v2/location/${name}`);
+async function fetchVersionEnglishName(name) {
+    const response = await fetch(`https://pokeapi.co/api/v2/version/${name}`);
     const data = await response.json();
-
-    const div = document.createElement('div');
-    div.innerText = JSON.stringify(data);
-    document.body.appendChild(div);
-}
-async function getRegionData(name) {
-    const response = await fetch(`https://pokeapi.co/api/v2/region/${name}`);
-    const data = await response.json();
-
-    const div = document.createElement('div');
-    div.innerText = JSON.stringify(data);
-    document.body.appendChild(div);
+    return findEnglishName(data);
 }
 
-function nameToApiName(name) {
-    return name.toLowerCase().replace(/\s/g, '-');
+function findEnglishName(data) {
+    return data.names.find(name => name.language.name === 'en').name;
 }

--- a/Website/MapExplorer/location-info.js
+++ b/Website/MapExplorer/location-info.js
@@ -1,4 +1,4 @@
-document.addEventListener("DOMContentLoaded", async function() {
+document.addEventListener("DOMContentLoaded", async function () {
     const urlParams = new URLSearchParams(window.location.search);
     const locationType = urlParams.get('type'); // location-area, location or region
     const location = urlParams.get('name');
@@ -72,7 +72,9 @@ async function getLocationAreaData(area, location) {
 
             for (const encounterDetail of version.encounter_details) {
                 const encounterText = document.createElement('p');
-                encounterText.innerText = `Method: ${encounterDetail.method.name}, Chance: ${encounterDetail.chance}%`;
+                const levelString = encounterDetail.min_level === encounterDetail.max_level ? "Level: " + encounterDetail.min_level : `Levels: ${encounterDetail.min_level}-${encounterDetail.max_level}`;
+                const conditionString = encounterDetail.condition_values.length > 0 ? `, Conditions: ${encounterDetail.condition_values.map(condition => condition.name).join(', ')}` : '';
+                encounterText.innerText = `Method: ${encounterDetail.method.name}, Chance: ${encounterDetail.chance}%, ${levelString}${conditionString}`;
                 card.appendChild(encounterText);
             }
         }
@@ -145,6 +147,7 @@ async function fetchAreaEnglishName(name) {
     const data = await response.json();
     return findEnglishName(data);
 }
+
 async function fetchVersionEnglishName(name) {
     const response = await fetch(`https://pokeapi.co/api/v2/version/${name}`);
     const data = await response.json();

--- a/Website/MapExplorer/location-info.js
+++ b/Website/MapExplorer/location-info.js
@@ -51,35 +51,43 @@ async function getLocationAreaData(area, location) {
         const li = document.createElement('li');
         li.classList.add('list-group-item');
 
-        const text = document.createElement('a');
-        text.classList.add('btn', 'btn-primary');
-        text.setAttribute('data-toggle', 'collapse');
-        text.href = `#collapse-${encounter.pokemon.name}`;
-        text.innerText = encounter.pokemon.name;
-        li.appendChild(text);
-
-        const collapse = document.createElement('div');
-        collapse.classList.add('collapse', 'mt-3');
-        collapse.id = `collapse-${encounter.pokemon.name}`;
         const card = document.createElement('div');
-        card.classList.add('card', 'card-body');
+        card.classList.add('mb-2', 'container', 'flex-row', 'd-flex');
+
+        const pokemonCard = document.createElement('div');
+            pokemonCard.classList.add('card', 'card-body', 'col-md-4', 'col-sm-12');
+        const link = document.createElement('a');
+        link.href = `../PokemonSubpage/pokemon.html?pokemon=${encounter.pokemon.name}`;
+        link.innerText = encounter.pokemon.name;
+        link.classList.add('card-title', 'btn', 'btn-primary');
+        pokemonCard.appendChild(link);
+
+        const image = document.createElement('img');
+        const pokemonId = encounter.pokemon.url.split('/')[6];
+        image.src = `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/${pokemonId}.png`;
+        image.alt = encounter.pokemon.name;
+        pokemonCard.appendChild(image);
+        card.appendChild(pokemonCard);
+
+        const encounterCard = document.createElement('div');
+        encounterCard.classList.add('card', 'card-body', 'col-md-8', 'col-sm-12');
 
         for (const version of encounter.version_details) {
             const versionName = await fetchVersionEnglishName(version.version.name);
             const versionHeader = document.createElement('h4');
             versionHeader.innerText = versionName;
-            card.appendChild(versionHeader);
+            encounterCard.appendChild(versionHeader);
 
             for (const encounterDetail of version.encounter_details) {
                 const encounterText = document.createElement('p');
                 const levelString = encounterDetail.min_level === encounterDetail.max_level ? "Level: " + encounterDetail.min_level : `Levels: ${encounterDetail.min_level}-${encounterDetail.max_level}`;
                 const conditionString = encounterDetail.condition_values.length > 0 ? `, Conditions: ${encounterDetail.condition_values.map(condition => condition.name).join(', ')}` : '';
                 encounterText.innerText = `Method: ${encounterDetail.method.name}, Chance: ${encounterDetail.chance}%, ${levelString}${conditionString}`;
-                card.appendChild(encounterText);
+                encounterCard.appendChild(encounterText);
             }
         }
-        collapse.appendChild(card);
-        li.appendChild(collapse);
+        card.appendChild(encounterCard);
+        li.appendChild(card);
 
         encounters.appendChild(li);
     }

--- a/Website/MapExplorer/location-info.js
+++ b/Website/MapExplorer/location-info.js
@@ -74,12 +74,18 @@ async function getLocationAreaData(area, location) {
 
         for (const version of encounter.version_details) {
             const versionName = await fetchVersionEnglishName(version.version.name);
-            const versionHeader = document.createElement('h4');
+            const versionHeader = document.createElement('a');
             versionHeader.innerText = versionName;
+            versionHeader.classList.add('mb-2', 'btn', 'btn-link');
+            versionHeader.setAttribute('data-toggle', 'collapse');
+            versionHeader.href = `#collapse-${version.version.name}-${pokemonId}`;
             encounterCard.appendChild(versionHeader);
 
             for (const encounterDetail of version.encounter_details) {
                 const encounterText = document.createElement('p');
+                encounterText.classList.add('collapse', 'mb-0');
+                encounterText.id = `collapse-${version.version.name}-${pokemonId}`;
+
                 const levelString = encounterDetail.min_level === encounterDetail.max_level ? "Level: " + encounterDetail.min_level : `Levels: ${encounterDetail.min_level}-${encounterDetail.max_level}`;
                 const conditionString = encounterDetail.condition_values.length > 0 ? `, Conditions: ${encounterDetail.condition_values.map(condition => condition.name).join(', ')}` : '';
                 encounterText.innerText = `Method: ${encounterDetail.method.name}, Chance: ${encounterDetail.chance}%, ${levelString}${conditionString}`;

--- a/Website/MapExplorer/map-explorer.html
+++ b/Website/MapExplorer/map-explorer.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Interactive Map</title>
+    <style>
+        .info-box {
+            position: absolute;
+            display: none;
+            background-color: white;
+            border: 1px solid #ccc;
+            padding: 10px;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        area:hover {
+            cursor: pointer;
+        }
+    </style>
+    <script src="map-explorer.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const areas = document.querySelectorAll('area');
+            const infoBox = document.getElementById('info-box');
+
+            areas.forEach(area => {
+                const coords = area.getAttribute('coords').split(',').map(Number);
+
+                area.addEventListener('mouseover', function (event) {
+                    infoBox.textContent = event.target.getAttribute('data-info');
+                    infoBox.style.display = 'block';
+                    infoBox.style.left = `${event.pageX + 10}px`;
+                    infoBox.style.top = `${event.pageY + 10}px`;
+
+                    area.addEventListener('mouseout', function () {
+                        infoBox.style.display = 'none';
+                    });
+
+                    area.addEventListener('click', function (event) {
+                        document.location = area.href;
+                    });
+                });
+            });
+        });
+    </script>
+</head>
+<body>
+<img src="../Images/Locations/Regions/kanto.png" usemap="#image-map" alt="Interactive Map">
+
+<div id="info-box" class="info-box"></div>
+</body>
+</html>

--- a/Website/MapExplorer/map-explorer.html
+++ b/Website/MapExplorer/map-explorer.html
@@ -45,8 +45,6 @@
     </script>
 </head>
 <body>
-<img src="../Images/Locations/Regions/kanto.png" usemap="#image-map" alt="Interactive Map">
-
 <div id="info-box" class="info-box"></div>
 </body>
 </html>

--- a/Website/MapExplorer/map-explorer.js
+++ b/Website/MapExplorer/map-explorer.js
@@ -4,13 +4,19 @@ document.addEventListener("DOMContentLoaded", async function() {
 
     document.title = `Explore ${region}`;
 
-    const image = document.createElement('img');
-    image.src = `../Images/Locations/Regions/${region.toLowerCase()}.png`;
-    document.body.appendChild(image);
-
+    // TEMP
     if (region !== 'kanto') {
+        const h = document.createElement('h1')
+        h.innerText = "Region not found";
+        document.body.appendChild(h);
         return;
     }
+
+    const image = document.createElement('img');
+    image.src = `../Images/Locations/Regions/${region.toLowerCase()}.png`;
+    image.useMap = '#image-map';
+    image.alt = "Map of " + region;
+    document.body.appendChild(image);
 
     const map = document.createElement('map');
     map.name = 'image-map';
@@ -24,13 +30,151 @@ document.addEventListener("DOMContentLoaded", async function() {
         area.setAttribute("data-info", city.name);
         map.appendChild(area);
     });
+    kantoData.routes.forEach(route => {
+        const area = document.createElement('area');
+        area.shape = 'rect';
+        area.coords = route.coords.join(',');
+        area.href = `location-info.html?type=location&name=${route.url}`;
+        area.alt = route.name;
+        area.setAttribute("data-info", route.name);
+        map.appendChild(area);
+    });
 
     document.body.appendChild(map);
 });
 
 const kantoData = {
     routes: [
-
+        {
+            name: "Route 1",
+            url: "kanto-route-1",
+            coords: [166, 488, 220, 600]
+        },
+        {
+            name: "Route 2",
+            url: "kanto-route-2",
+            coords: [166, 430, 218, 216]
+        },
+        {
+            name: "Route 3",
+            url: "kanto-route-3",
+            coords: [220, 216, 380, 162]
+        },
+        {
+            name: "Route 3",
+            url: "kanto-route-3",
+            coords: [328, 160, 393, 108]
+        },
+        {
+            name: "Route 4",
+            url: "kanto-route-4",
+            coords: [425, 160, 598, 108]
+        },
+        {
+            name: "Route 5",
+            url: "kanto-route-5",
+            coords: [600, 162, 650, 268]
+        },
+        {
+            name: "Route 6",
+            url: "kanto-route-6",
+            coords: [600, 324, 650, 486]
+        },
+        {
+            name: "Route 7",
+            url: "kanto-route-7",
+            coords: [490, 324, 598, 270]
+        },
+        {
+            name: "Route 8",
+            url: "kanto-route-8",
+            coords: [653, 323, 814, 271]
+        },
+        {
+            name: "Route 9",
+            url: "kanto-route-9",
+            coords: [653, 162, 870, 110]
+        },
+        {
+            name: "Route 10",
+            url: "kanto-route-10",
+            coords: [815, 200, 870, 270]
+        },
+        {
+            name: "Route 11",
+            url: "kanto-route-11",
+            coords: [653, 540, 813, 487]
+        },
+        {
+            name: "Route 12",
+            url: "kanto-route-12",
+            coords: [814, 325, 867, 595]
+        },
+        {
+            name: "Route 13",
+            url: "kanto-route-13",
+            coords: [653, 595, 867, 650]
+        },
+        {
+            name: "Route 14",
+            url: "kanto-route-14",
+            coords: [705, 650, 650, 702]
+        },
+        {
+            name: "Route 15",
+            url: "kanto-route-15",
+            coords: [545, 755, 706, 702]
+        },
+        {
+            name: "Route 16",
+            url: "kanto-route-16",
+            coords: [273, 273, 434, 324]
+        },
+        {
+            name: "Route 17",
+            url: "kanto-route-17",
+            coords: [273, 323, 325, 712]
+        },
+        {
+            name: "Route 18",
+            url: "kanto-route-18",
+            coords: [490, 756, 274, 704]
+        },
+        {
+            name: "Route 19",
+            url: "kanto-route-19",
+            coords: [490, 757, 542, 811]
+        },
+        {
+            name: "Route 20",
+            url: "kanto-route-20",
+            coords: [220, 812, 545, 853]
+        },
+        {
+            name: "Route 21",
+            url: "kanto-route-21",
+            coords: [166, 650, 218, 811]
+        },
+        {
+            name: "Route 22",
+            url: "kanto-route-22",
+            coords: [58, 483, 165, 432]
+        },
+        {
+            name: "Route 23",
+            url: "kanto-route-23",
+            coords: [110, 430, 58, 165]
+        },
+        {
+            name: "Route 24",
+            url: "kanto-route-24",
+            coords: [598, 107, 652, 55]
+        },
+        {
+            name: "Route 25",
+            url: "kanto-route-25",
+            coords: [598, 0, 760, 53]
+        }
     ],
     cities: [
         {

--- a/Website/MapExplorer/map-explorer.js
+++ b/Website/MapExplorer/map-explorer.js
@@ -213,8 +213,8 @@ const kantoData = {
             coords: [595, 270, 650, 324]
         },
         {
-            name: "Vermillion City",
-            url: "vermillion-city",
+            name: "Vermilion City",
+            url: "vermilion-city",
             coords: [595, 488, 650, 540]
         },
         {
@@ -228,8 +228,8 @@ const kantoData = {
             coords: [437, 270, 490, 324]
         },
         {
-            name: "Fuschia City",
-            url: "fuschia-city",
+            name: "Fuchsia City",
+            url: "fuchsia-city",
             coords: [490, 705, 543, 757]
         },
         {

--- a/Website/MapExplorer/map-explorer.js
+++ b/Website/MapExplorer/map-explorer.js
@@ -1,0 +1,117 @@
+document.addEventListener("DOMContentLoaded", async function() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const region = urlParams.get('region');
+
+    document.title = `Explore ${region}`;
+
+    const image = document.createElement('img');
+    image.src = `../Images/Locations/Regions/${region.toLowerCase()}.png`;
+    document.body.appendChild(image);
+
+    if (region !== 'kanto') {
+        return;
+    }
+
+    const map = document.createElement('map');
+    map.name = 'image-map';
+
+    kantoData.cities.forEach(city => {
+        const area = document.createElement('area');
+        area.shape = 'rect';
+        area.coords = city.coords.join(',');
+        area.href = `location-info.html?type=location&name=${city.url}`;
+        area.alt = city.name;
+        area.setAttribute("data-info", city.name);
+        map.appendChild(area);
+    });
+
+    document.body.appendChild(map);
+});
+
+const kantoData = {
+    routes: [
+
+    ],
+    cities: [
+        {
+            name: "Indigo Plateau",
+            url: "indigo-plateau",
+            coords: [57, 108, 110, 162]
+        },
+        {
+            name: "Pewter City",
+            url: "pewter-city",
+            coords: [165, 165, 220, 220]
+        },
+        {
+            name: "Viridian City",
+            url: "viridian-city",
+            coords: [166, 433, 220, 487]
+        },
+        {
+            name: "Pallet Town",
+            url: "pallet-town",
+            coords: [166, 600, 220, 650]
+        },
+        {
+            name: "Cinnabar Island",
+            url: "cinnabar-island",
+            coords: [166, 813, 220, 863]
+        },
+        {
+            name: "Cerulean City",
+            url: "cerulean-city",
+            coords: [595, 110, 650, 163]
+        },
+        {
+            name: "Saffron City",
+            url: "saffron-city",
+            coords: [595, 270, 650, 324]
+        },
+        {
+            name: "Vermillion City",
+            url: "vermillion-city",
+            coords: [595, 488, 650, 540]
+        },
+        {
+            name: "Lavender Town",
+            url: "lavender-town",
+            coords: [815, 270, 870, 324]
+        },
+        {
+            name: "Celadon City",
+            url: "celadon-city",
+            coords: [437, 270, 490, 324]
+        },
+        {
+            name: "Fuschia City",
+            url: "fuschia-city",
+            coords: [490, 705, 543, 757]
+        },
+        {
+            name: "Victory Road",
+            url: "victory-road",
+            coords: [71, 230, 97, 256]
+        },
+        {
+            name: "Viridian Forest",
+            url: "viridian-forest",
+            coords: [180, 230, 204, 255]
+        },
+        {
+            name: "Mt. Moon",
+            url: "mt-moon",
+            coords: [395, 123, 420, 150]
+        },
+        {
+            name: "Rock Tunnel",
+            url: "rock-tunnel",
+            coords: [830, 175, 853, 201]
+        },
+        {
+            name: "Seafoam Islands",
+            url: "seafoam-islands",
+            coords: [342, 827, 367, 850]
+        }
+    ]
+}

--- a/Website/PokemonSubpage/pokemon.css
+++ b/Website/PokemonSubpage/pokemon.css
@@ -143,6 +143,9 @@ a:visited {
 a:hover {
     text-decoration: underline;
 }
+a.location-link {
+    color: inherit;
+}
 
 
 img {

--- a/Website/PokemonSubpage/pokemon.html
+++ b/Website/PokemonSubpage/pokemon.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Error</title>
-    <link rel="stylesheet" href="subpage.css">
+    <link rel="stylesheet" href="pokemon.css">
     <link rel="stylesheet" href="../navbar.css">
 
     <script src="../TypeCalc/calculator-methods.js"></script>

--- a/Website/PokemonSubpage/pokemon.js
+++ b/Website/PokemonSubpage/pokemon.js
@@ -18,6 +18,7 @@ document.addEventListener("DOMContentLoaded", async function() {
 
     const imageElement = document.createElement("img");
     imageElement.src = data.sprites.front_default;
+    imageElement.alt = formatName(pokemonName);
     imageElement.classList.add("float-left");
     document.body.appendChild(imageElement);
 
@@ -149,7 +150,9 @@ async function buildLocationMap(encounter_url) {
     list.classList.add("location-list");
     for (const location of data) {
         const item = document.createElement("li");
-        item.innerHTML = location.location_area.name;
+        item.innerHTML = `<a class="location-link"
+            href="../MapExplorer/location-info.html?type=location-area&name=${location.location_area.name}">
+            ${location.location_area.name}</a>`;
         list.appendChild(item);
     }
     div.appendChild(list);

--- a/Website/PokemonSubpage/pokemon.js
+++ b/Website/PokemonSubpage/pokemon.js
@@ -56,7 +56,7 @@ function getTypeLink(type) {
 }
 function getKindLink(kind) {
     const kindName = kind === "pseudo" ? "Pseudo-Legendary" : kind;
-    return `<a href="../KindOfPokemons-Subpage/kindOfPokemon.html#${kind}">${formatName(kindName)}</a>`;
+    return `<a href="../KindOfPokemonSubpage/kinds-of-pokemon.html#${kind}">${formatName(kindName)}</a>`;
 }
 
 function buildWeaknessTable(types) {


### PR DESCRIPTION
closes #24 

This pull request adds a map explorer to explore the currently supported regions
- kanto

and the **locations and location-areas** of all regions.

Features:
- Map explorer for kanto region
- Info for locations and location-areas
- Pokemon encounters with **version, levels and conditions**

TODO on target branch (main):
- Add explorer to navbar (optional)